### PR TITLE
Increase size of term name for VocabularyTerm

### DIFF
--- a/code/VocabularyTerm.php
+++ b/code/VocabularyTerm.php
@@ -15,7 +15,7 @@ class VocabularyTerm extends DataObject {
    const AUTO_COMPLETE_FORMAT = '$Term.RAW ($Vocabulary.MachineName.RAW:$MachineName.RAW)';
 
    static $db = array(
-      'Term'        => 'VARCHAR(64)',
+      'Term'        => 'VARCHAR(128)',
       'MachineName' => 'VARCHAR(32)',
    );
 


### PR DESCRIPTION
To avoid displaying truncated Term names, increase the size to 128 characters. 
